### PR TITLE
Could com.yami.shop:yami-shop-admin:0.0.1-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/yami-shop-admin/pom.xml
+++ b/yami-shop-admin/pom.xml
@@ -15,6 +15,60 @@
             <groupId>com.yami.shop</groupId>
             <artifactId>yami-shop-service</artifactId>
             <version>${yami.shop.version}</version>
+	    <exclusions>
+		<exclusion>
+		    <artifactId>aliyun-java-sdk-core</artifactId>
+		    <groupId>com.aliyun</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>jboss-marshalling</artifactId>
+		    <groupId>org.jboss.marshalling</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>activation</artifactId>
+		    <groupId>javax.activation</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>jsoup</artifactId>
+		    <groupId>org.jsoup</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>jaxb-api</artifactId>
+		    <groupId>javax.xml.bind</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>error_prone_annotations</artifactId>
+		    <groupId>com.google.errorprone</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>checker-qual</artifactId>
+		    <groupId>org.checkerframework</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>aliyun-java-sdk-dysmsapi</artifactId>
+		    <groupId>com.aliyun</groupId>
+		</exclusion>
+		<exclusion>
+		  <artifactId>stax-api</artifactId>
+		  <groupId>javax.xml.stream</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>annotations</artifactId>
+		    <groupId>org.jetbrains</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>jboss-marshalling-river</artifactId>
+		    <groupId>org.jboss.marshalling</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>mysql-connector-j</artifactId>
+		    <groupId>com.mysql</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>ini4j</artifactId>
+		    <groupId>org.ini4j</groupId>
+		</exclusion>
+      	    </exclusions>
         </dependency>
         <dependency>
             <groupId>com.yami.shop</groupId>
@@ -25,6 +79,12 @@
 	       <groupId>org.apache.poi</groupId>
 	       <artifactId>poi-ooxml</artifactId>
 	       <version>${poi.version}</version>
+	       <exclusions>
+	           <exclusion>
+	               <artifactId>curvesapi</artifactId>
+		       <groupId>com.github.virtuald</groupId>
+		   </exclusion>
+	       </exclusions>
        </dependency>
         <dependency>
             <groupId>com.yami.shop</groupId>
@@ -39,6 +99,34 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
         </dependency>
+	<dependency>
+	    <groupId>org.apache.httpcomponents</groupId>
+	    <artifactId>httpclient</artifactId>
+	 </dependency>
+	 <dependency>
+	     <groupId>org.apache.httpcomponents</groupId>
+	     <artifactId>httpcore</artifactId>
+	 </dependency>
+	 <dependency>
+	     <groupId>org.jacoco</groupId>
+	     <artifactId>org.jacoco.agent</artifactId>
+	     <version>0.8.3</version>
+	     <classifier>runtime</classifier>
+	     <scope>compile</scope>
+	</dependency>
+	<dependency>
+	     <groupId>commons-logging</groupId>
+	     <artifactId>commons-logging</artifactId>
+	     <version>1.2</version>
+	     <scope>compile</scope>
+	</dependency>
+	<dependency>
+	     <groupId>org.springframework.boot</groupId>
+	     <artifactId>spring-boot-configuration-processor</artifactId>
+	     <version>3.0.4</version>
+	     <scope>provided</scope>
+	     <optional>true</optional>
+	</dependency>
     </dependencies>
 
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/126549527/231369955-e15149fd-3b4e-45f6-b945-8d521334e1c1.png)
![image](https://user-images.githubusercontent.com/126549527/231370016-7ea9778a-f252-4839-88dd-6c3dca8db8ad.png)
![image](https://user-images.githubusercontent.com/126549527/231370192-cf43b785-b8b9-4bb6-84d6-3103e396e060.png)
![image](https://user-images.githubusercontent.com/126549527/231370244-64379ff2-468d-46f7-8c71-ed784957228b.png)
![image](https://user-images.githubusercontent.com/126549527/231370302-88f9460a-7785-4681-92b5-bc325a788c48.png)
![image](https://user-images.githubusercontent.com/126549527/231370408-6687d0ff-7924-4da9-b538-e1bc8110ccf2.png)

Hi, I found that **_com.yami.shop:yami-shop-admin:0.0.1-SNAPSHOT_**’s pom file introduced **_193_** dependencies. However, among them, **_15_** libraries (**_8%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_7_**  redundant libraries have not been maintained by developers for more than **_3_** years (outdated dependencies).



Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_com.yami.shop:yami-shop-admin:0.0.1-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
        org.jetbrains:annotations:13.0:compile [17 KB]
        javax.xml.bind:jaxb-api:2.1:compile [87 KB]
        com.github.virtuald:curvesapi:1.07:compile [109 KB]
        org.jboss.marshalling:jboss-marshalling-river:2.0.11.Final:compile [86 KB]
        javax.activation:activation:1.1:compile [61 KB]
        javax.xml.stream:stax-api:1.0-2:compile [22 KB]
        org.jboss.marshalling:jboss-marshalling:2.0.11.Final:compile [218 KB]
        com.aliyun:aliyun-java-sdk-dysmsapi:1.1.0:compile [20 KB]
        org.checkerframework:checker-qual:3.12.0:compile [203 KB]
        com.aliyun:aliyun-java-sdk-core:4.3.9:compile [171 KB]
        com.google.errorprone:error_prone_annotations:2.11.0:compile [15 KB]
        com.mysql:mysql-connector-j:8.0.32:compile [2 MB]
        org.jsoup:jsoup:1.15.3:compile [427 KB]
        org.ini4j:ini4j:0.5.4:compile [99 KB]
#### Redundant direct dependencies inherited from parent pom:
        org.springframework.boot:spring-boot-configuration-processor:3.0.4:compile [118 KB]

## Outdated dependencies
org.jetbrains:annotations:13.0 (**_3403_** days without maintenance)
javax.xml.bind:jaxb-api:2.1 (**_5672_** days without maintenance)
javax.activation:activation:1.1 (**_6188_** days without maintenance)
org.ini4j:ini4j:0.5.4 (**_2976_** days without maintenance)
com.aliyun:aliyun-java-sdk-core:4.3.9 (**_1475_** days without maintenance)
javax.xml.stream:stax-api:1.0-2 (**_5302_** days without maintenance)
com.aliyun:aliyun-java-sdk-dysmsapi:1.1.0 (**_1889_** days without maintenance)